### PR TITLE
Make internals visible for unit tests

### DIFF
--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -34,4 +34,3 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
-[assembly: InternalsVisibleTo("LiveSplit.UnitTests")]

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -34,3 +34,4 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: InternalsVisibleTo("LiveSplit.UnitTests")]

--- a/TimeFormatters/DeltaComponentFormatter.cs
+++ b/TimeFormatters/DeltaComponentFormatter.cs
@@ -2,7 +2,7 @@
 
 namespace LiveSplit.TimeFormatters
 {
-    class DeltaComponentFormatter : ITimeFormatter
+    public class DeltaComponentFormatter : ITimeFormatter
     {
         public TimeAccuracy Accuracy { get; set; }
         public bool DropDecimals { get; set; }


### PR DESCRIPTION
Allow unit tests to be created for all TimeFormatters. See: https://github.com/LiveSplit/LiveSplit/pull/1446
